### PR TITLE
Fix server startup without exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "game",
   "version": "1.0.0",
   "description": "",
-  "main": "server.js",
+  "main": "public/finding-game/server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node public/finding-game/server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- run server from public/finding-game via npm start
- drop Express and module exports in favor of a minimal static HTTP server

## Testing
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_689a9f906b448330a0bc4589673cec9e