### PR TITLE
Fix WebSocket usage and invite link routing

### DIFF
--- a/public/finding-game/server.js
+++ b/public/finding-game/server.js
@@ -371,7 +371,8 @@ module.exports = { setupFindingGame };
 if (require.main === module) {
     const server = http.createServer((req, res) => {
         // Normalize URL to map /finding-game and /finding-game/* to local files
-        let urlPath = req.url;
+        const { pathname } = new URL(req.url, `http://${req.headers.host}`);
+        let urlPath = pathname;
 
         if (urlPath === "/" || urlPath === BASE_PATH) {
             urlPath = "/index.html";

--- a/public/racing/server.js
+++ b/public/racing/server.js
@@ -1,3 +1,8 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const WebSocket = require('ws');
+
 const PORT = process.env.PORT || 3000;
 const PUBLIC_DIR = __dirname;
 const BASE_PATH = '/racing';
@@ -131,7 +136,8 @@ module.exports = { setupRacingGame };
 
 if (require.main === module) {
   const server = http.createServer((req, res) => {
-    let urlPath = req.url;
+    const { pathname } = new URL(req.url, `http://${req.headers.host}`);
+    let urlPath = pathname;
     if (urlPath === '/' || urlPath === BASE_PATH) {
       urlPath = '/index.html';
     } else if (urlPath.startsWith(BASE_PATH + '/')) {

--- a/server.js
+++ b/server.js
@@ -14,9 +14,11 @@ function serveStatic(req, res) {
     { base: '/racing', dir: path.join(__dirname, 'public', 'racing') },
   ];
 
+  const { pathname } = new URL(req.url, `http://${req.headers.host}`);
+
   for (const { base, dir } of routes) {
-    if (req.url === base || req.url.startsWith(base + '/')) {
-      let urlPath = req.url;
+    if (pathname === base || pathname.startsWith(base + '/')) {
+      let urlPath = pathname;
       if (urlPath === '/' || urlPath === base) {
         urlPath = '/index.html';
       } else {


### PR DESCRIPTION
## Summary
- require WebSocket and other modules in racing server
- ignore query strings when serving static files so invite links work

## Testing
- `npm test`
- `node server.js & PID=$!; sleep 1; curl -i http://localhost:3000/finding-game?code=BESPHQ | head -n 20; kill $PID; wait $PID 2>/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_689abd3763548330b9bd240090e8fd1f