### PR TITLE
Add copy link controls and expand racing game rules

### DIFF
--- a/public/finding-game/index.html
+++ b/public/finding-game/index.html
@@ -431,6 +431,7 @@
       <div class="row">
         <h1>Find the number</h1>
         <button id="leaveBtn" class="btn danger" style="display:none;">Leave</button>
+        <button id="copyLinkBtn" class="btn">Copy Link</button>
         <div class="muted" id="shareLine" style="margin-left:auto;display:none;"></div>
       </div>
 
@@ -499,6 +500,7 @@
       const createBtn = document.getElementById('createBtn');
       const joinBtn = document.getElementById('joinBtn');
       const leaveBtn = document.getElementById('leaveBtn');
+      const copyLinkBtn = document.getElementById('copyLinkBtn');
       const errEl = document.getElementById('err');
       const shareLine = document.getElementById('shareLine');
 
@@ -684,6 +686,11 @@
       joinGameBtn.onclick = () => { if (!myLobbyCode || !myPlayerId) return; ws.send(JSON.stringify({ type: 'join_game', code: myLobbyCode, playerId: myPlayerId })) };
       leaveGameBtn.onclick = () => { if (!myLobbyCode || !myPlayerId) return; ws.send(JSON.stringify({ type: 'leave_game', code: myLobbyCode, playerId: myPlayerId })) };
       leaveBtn.onclick = () => { location.href = location.origin + location.pathname };
+      copyLinkBtn.onclick = () => {
+        navigator.clipboard.writeText(location.href);
+        copyLinkBtn.textContent = 'Copied!';
+        setTimeout(() => copyLinkBtn.textContent = 'Copy Link', 1500);
+      };
 
       document.addEventListener('keydown', (e) => { if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'f') e.preventDefault(); });
       wsConnect();

--- a/public/racing/index.html
+++ b/public/racing/index.html
@@ -256,6 +256,7 @@
       <h1>Terract – Tower Race</h1>
       <div class="right">
         <div id="roomCode" class="muted"></div>
+        <button id="copyLinkBtn" class="btn">Copy Link</button>
         <button id="startBtn" style="display:none;">Start</button>
         <button id="restartBtn" style="display:none;">Restart</button>
         <div id="gravity" class="muted">Speed: —</div>
@@ -264,7 +265,7 @@
     </header>
 
     <div class="wrap">
-      <canvas id="board" width="200" height="400"></canvas>
+      <canvas id="board" width="240" height="480"></canvas>
     </div>
 
     <aside>
@@ -308,12 +309,13 @@
         const createBtn = document.getElementById('createBtn');
         const joinBtn = document.getElementById('joinBtn');
         const errEl = document.getElementById('err');
+        const copyLinkBtn = document.getElementById('copyLinkBtn');
 
         let ws = null;
         let me = null; // my id
-        let board = Array.from({ length: 20 }, () => Array(10).fill(null));
+        let board = Array.from({ length: 24 }, () => Array(12).fill(null));
         let players = {};
-        let width = 10, height = 20;
+        let width = 12, height = 24;
         let currentTurn = null;
         let hostId = null;
 
@@ -388,6 +390,12 @@
           startGame(code, name);
         };
 
+        copyLinkBtn.onclick = () => {
+          navigator.clipboard.writeText(location.href);
+          copyLinkBtn.textContent = 'Copied!';
+          setTimeout(() => copyLinkBtn.textContent = 'Copy Link', 1500);
+        };
+
       function draw() {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
         ctx.fillStyle = '#7b8aa0';
@@ -403,6 +411,9 @@
             if (c) {
               ctx.fillStyle = c;
               ctx.fillRect(x * size, (y + 1) * size, size, size);
+              ctx.strokeStyle = '#142033';
+              ctx.lineWidth = 1;
+              ctx.strokeRect(x * size + 0.5, (y + 1) * size + 0.5, size - 1, size - 1);
             }
           }
         }
@@ -417,6 +428,9 @@
                 const x = (p.active.x + c) * size;
                 const y = (p.active.y + r + 1) * size;
                 ctx.fillRect(x, y, size, size);
+                ctx.strokeStyle = '#142033';
+                ctx.lineWidth = 1;
+                ctx.strokeRect(x + 0.5, y + 0.5, size - 1, size - 1);
               }
             }
           }
@@ -535,8 +549,8 @@
       powerButtons.p2.onclick = () => {
         const mePl = players[me];
         if (currentTurn === me || !mePl || mePl.usedPower) return;
-        const col = prompt('Column (0-9)?', '5');
-        const cNum = Math.max(0, Math.min(9, parseInt(col || '5', 10)));
+        const col = prompt('Column (0-11)?', '5');
+        const cNum = Math.max(0, Math.min(11, parseInt(col || '5', 10)));
         send({ type: 'power', id: me, kind: 'columnBomb', col: cNum });
       };
       powerButtons.p3.onclick = () => { const mePl = players[me]; if (currentTurn !== me && mePl && !mePl.usedPower) send({ type: 'power', id: me, kind: 'freezeRival' }); };

--- a/public/racing/server.js
+++ b/public/racing/server.js
@@ -8,8 +8,8 @@ const PUBLIC_DIR = __dirname;
 const BASE_PATH = '/racing';
 
 // Board
-const WIDTH = 10;
-const HEIGHT = 20;
+const WIDTH = 12;
+const HEIGHT = 24;
 const MAX_PLAYERS = 4;
 
 // Timing
@@ -232,24 +232,23 @@ function setupRacingGame(wss) {
     const kind = p.queue.shift();
     const shape = SHAPES[kind][0];
     const w = shape[0].length;
-    const x = Math.floor((WIDTH - w) / 2);
+    let x = 5;
+    if (x + w > WIDTH) x = WIDTH - w;
     const y = 0;
     const base = { ownerId: p.id, color: p.color, kind, rot: 0, x, y, lastFallAt: Date.now(), groundedAt: null };
-    let spawned = base;
-    const kicks = [0, -1, 1, -2, 2];
-    let ok = false;
-    for (const k of kicks) {
-      const tryP = { ...base, x: base.x + k };
-      if (canPlace(room.board, tryP)) { spawned = tryP; ok = true; break; }
-    }
-    if (!ok) {
+    if (!canPlace(room.board, base)) {
       if (p.ap >= 10) {
         room.winnerId = p.id;
         broadcast(room, { type: 'winner', winnerId: p.id, name: p.name });
+      } else {
+        const others = Array.from(room.players.keys()).filter(id => id !== p.id);
+        const winnerId = others[0] || null;
+        room.winnerId = winnerId;
+        broadcast(room, { type: 'winner', winnerId, name: winnerId ? room.players.get(winnerId).name : undefined });
       }
       return;
     }
-    p.active = spawned;
+    p.active = base;
   }
 
   function ensureActivePieces(room) {


### PR DESCRIPTION
## Summary
- add a Copy Link button to both game UIs for easy sharing
- enlarge racing board and render inner cell borders
- spawn racing pieces in column 5 and end game when topping out without 10 AP

## Testing
- `npm test`
- `node -e "require('./public/racing/server.js'); console.log('server ok')"`


------
https://chatgpt.com/codex/tasks/task_e_689af22fb7608330b0355bc459520035