### PR TITLE
Ensure racing game restarts immediately

### DIFF
--- a/public/racing/server.js
+++ b/public/racing/server.js
@@ -485,6 +485,7 @@ function setupRacingGame(wss) {
         room.turnOrder = Array.from(room.players.keys());
         room.turnIndex = 0;
         room.turnId = room.turnOrder[0] || null;
+        room.started = true;
         for (const pl of room.players.values()) {
           pl.points = 0;
           pl.queue = makeQueue();


### PR DESCRIPTION
## Summary
- Start new race immediately when host presses **Restart**

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f246a765483309b28b4f8315dff1b