### PR TITLE
Restart race immediately after clicking Restart

### DIFF
--- a/public/racing/server.js
+++ b/public/racing/server.js
@@ -485,6 +485,7 @@ function setupRacingGame(wss) {
         room.turnOrder = Array.from(room.players.keys());
         room.turnIndex = 0;
         room.turnId = room.turnOrder[0] || null;
+        room.started = true;
         for (const pl of room.players.values()) {
           pl.points = 0;
           pl.queue = makeQueue();


### PR DESCRIPTION
## Summary
- Start the race automatically when host presses **Start** or **Restart**
- Remove need to click **Start** after pressing **Restart**

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f246a765483309b28b4f8315dff1b