### PR TITLE
Scale racing board width with player count

### DIFF
--- a/public/racing/index.html
+++ b/public/racing/index.html
@@ -309,7 +309,7 @@
         const setMaxPointsBtn = document.getElementById('setMaxPointsBtn');
         let ws = null;
         let me = null; // my id
-        let width = 12, height = 24;
+        let width = 6, height = 24;
         let board = Array.from({ length: height }, () => Array(width).fill(null));
         let players = {};
         let currentTurn = null;

--- a/public/racing/server.js
+++ b/public/racing/server.js
@@ -8,12 +8,12 @@ const PUBLIC_DIR = __dirname;
 const BASE_PATH = '/racing';
 
 // Board
-let WIDTH = 12;
+let WIDTH = 6;
 const HEIGHT = 24;
 const MAX_PLAYERS = 4;
 
 function calcWidth(playerCount) {
-  return Math.min(11, 2 * playerCount + 3);
+  return Math.max(6, Math.min(12, playerCount * 2 + 4));
 }
 
 // Timing


### PR DESCRIPTION
## Summary
- Derive racing board width from number of players
- Set default client width to match dynamic sizing

## Testing
- `npm test`
- `node -e "require('./public/racing/server')"`


------
https://chatgpt.com/codex/tasks/task_e_689f3ce7cc448330bb8c8389911546ac