### PR TITLE
Spawn pieces above board and allow pre-positioning

### DIFF
--- a/public/racing/index.html
+++ b/public/racing/index.html
@@ -541,7 +541,7 @@
         e.preventDefault();
         const mePl = players[me];
         if (!mePl || mePl.eliminated) return;
-        if (currentTurn !== me) return;
+        if (currentTurn !== me && act !== 'left' && act !== 'right') return;
         send({ type: 'move', id: me, dir: act });
       });
 


### PR DESCRIPTION
## Summary
- Spawn new bricks above the board and allow placement with negative coordinates.
- Pre-summon the next player's brick so they can move left/right before their turn.
- Eliminate players if a locked brick remains above the board.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a21391a2708330bdbd40b83b02b330